### PR TITLE
Started the first few code blocks for review, and i put them in an in…

### DIFF
--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -28,20 +28,12 @@ else
   sudo install -m 0755 -d /etc/apt/keyrings
 fi
 
-# Adding gpg keyring
+# Adding gpg keyring, and configuring
 if (which gpg)
 then
   echo "gpg keyring exists, and configured"
 else
   echo "configuring gpg keyring"
-  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc 
+  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc chmod a+r /etc/apt/keyrings/docker.asc
 fi
 
-# Configuring keyring
-if (test -f /etc/bin/keyrings/docker.asc)
-then
-  echo "gpg keyring configured"
-else
-  echo "configuring keyring"
-  sudo chmod a+r /etc/apt/keyrings/docker.asc
-fi

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -1,5 +1,5 @@
- Update
-sudo apt-get update
+# Update
+sudo apt update
 
 # Installing ca-certificates
 if (which ca-certificates)
@@ -7,7 +7,7 @@ then
   echo "ca-certificates already installed"
 else
   echo "Installing ca-certificates"
-  sudo apt-get install ca-certificates
+  sudo apt install ca-certificates
 fi
 
 # Installing curl
@@ -16,7 +16,7 @@ then
   echo "curl already installed"
 else
   echo "Installing curl"
-  sudo apt-get install curl
+  sudo apt install curl
 fi
 
 # Creating a keyrings directory

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -19,6 +19,7 @@ else
   sudo apt-get install curl
 fi
 
+# Creating a keyrings directory
 if (test -f /etc/bin/keyrings)
 then
   echo "creating keyrings"
@@ -27,7 +28,7 @@ else
   sudo install -m 0755 -d /etc/apt/keyrings
 fi
 
-# Adding, and configuration of gpg keyring
+# Adding gpg keyring
 if (which gpg)
 then
   echo "gpg keyring exists, and configured"
@@ -36,6 +37,7 @@ else
   sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc 
 fi
 
+# Configuring keyring
 if (test -f /etc/bin/keyrings/docker.asc)
 then
   echo "gpg keyring configured"

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -7,7 +7,7 @@ then
   echo "ca-certificates already installed"
 else
   echo "Installing ca-certificates"
-  sudo apt install ca-certificates
+  sudo apt install -y ca-certificates
 fi
 
 # Installing curl
@@ -16,11 +16,11 @@ then
   echo "curl already installed"
 else
   echo "Installing curl"
-  sudo apt install curl
+  sudo apt install -y curl 
 fi
 
 # Creating a keyrings directory
-if (test -f /etc/bin/keyrings)
+if (test -d /etc/bin/keyrings)
 then
   echo "creating keyrings"
 else
@@ -35,5 +35,13 @@ then
 else
   echo "configuring gpg keyring"
   sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; sudo chmod a+r /etc/apt/keyrings/docker.asc
+fi
+
+if (test -f /etc/bin/keyrings/docker.asc)
+then
+  echo " gpg keyring already configured"
+else
+  echo "configuring gpg keyrings"
+  sudo chmod a+r /etc/apt/keyrings/docker.asc
 fi
 

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -1,4 +1,4 @@
-# Update
+ Update
 sudo apt update
 
 # Installing ca-certificates
@@ -19,20 +19,12 @@ else
   sudo apt install curl
 fi
 
-if (test -f /etc/bin/keyring/docker.asc)
+if (test -f /etc/bin/keyring)
 then
   echo "creatingg keyring"
 else
   echo "Creating keyring"
   sudo apt install /etc/apt/keyrings
-fi
-
-if (test -f /etc/bin/keyring/docker.asc)
-then
-  echo "gpg keyring configured"
-else
-  echo "configuring keyring"
-  sudo chmod a+r /etc/apt/keyrings/docker.asc
 fi
 
 # Adding, and configuration of gpg keyring
@@ -41,6 +33,13 @@ then
   echo "gpg keyring exists, and configured"
 else
   echo "configuring gpg keyring"
-  sudo apt install /etc/apt/keyrings
   sudo curl-fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc 
+fi
+
+if (test -f /etc/bin/keyring/docker.asc)
+then
+  echo "gpg keyring configured"
+else
+  echo "configuring keyring"
+  sudo chmod a+r /etc/apt/keyrings/docker.asc
 fi

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -1,9 +1,18 @@
 # Update
 sudo apt update
 
+# Installing ca-certificates
+if (which ca-certificates)
+then
+  echo "ca-certificates already installed"
+else
+  echo "Installing ca-certificates"
+  sudo apt install ca-certificates
+fi
+
 # Installing curl
 if (which curl)
-then 
+then
   echo "curl already installed"
 else
   echo "Installing curl"
@@ -11,11 +20,10 @@ else
 fi
 
 # Adding, and configuration of gpg keyring
-if [ -f /etc/apt/keyrings/docker.asc ]
-then 
-  echo "gpg keyring alread configured"
-else 
+if (test -f /usr/bin/keyring/docker.asc)
+then
+  echo "gpg keyring exists, and configured"
+else
   echo "configuring gpg keyring"
-  sudo apt install -m 0755 -d /etc/apt/keyrings curl -fssL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc chmod a+r /etc/apt/keyrings/docker.asc
+  sudo apt install -m 0755 -d /etc/apt/keyrings curl-fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc chmod a+r /etc/apt/keyrings/docker.asc
 fi
-

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -16,6 +16,6 @@ then
   echo "gpg keyring alread configured"
 else 
   echo "configuring gpg keyring"
-  sudo install -m 0755 -d /etc/apt/keyrings curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc chmod a+r /etc/apt/keyrings/docker.asc
+  sudo apt install -m 0755 -d /etc/apt/keyrings curl -fssL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc chmod a+r /etc/apt/keyrings/docker.asc
 fi
 

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -34,6 +34,6 @@ then
   echo "gpg keyring exists, and configured"
 else
   echo "configuring gpg keyring"
-  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc chmod a+r /etc/apt/keyrings/docker.asc
+  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; sudo chmod a+r /etc/apt/keyrings/docker.asc
 fi
 

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -19,11 +19,28 @@ else
   sudo apt install curl
 fi
 
+if (test -f /etc/bin/keyring/docker.asc)
+then
+  echo "creatingg keyring"
+else
+  echo "Creating keyring"
+  sudo apt install /etc/apt/keyrings
+fi
+
+if (test -f /etc/bin/keyring/docker.asc)
+then
+  echo "gpg keyring configured"
+else
+  echo "configuring keyring"
+  sudo chmod a+r /etc/apt/keyrings/docker.asc
+fi
+
 # Adding, and configuration of gpg keyring
-if (test -f /usr/bin/keyring/docker.asc)
+if (which gpg)
 then
   echo "gpg keyring exists, and configured"
 else
   echo "configuring gpg keyring"
-  sudo apt install -m 0755 -d /etc/apt/keyrings curl-fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc chmod a+r /etc/apt/keyrings/docker.asc
+  sudo apt install /etc/apt/keyrings
+  sudo curl-fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc 
 fi

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -28,21 +28,19 @@ else
   sudo install -m 0755 -d /etc/apt/keyrings
 fi
 
-# Adding gpg keyring
+# Adding a gpg keyring
 if (which gpg)
 then
   echo "gpg keyring exists, and configured"
 else
   echo "configuring gpg keyring"
-  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+  curl -fsSL https://download.docker.com/linux/debian/gpg | sudo -H gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 fi
- 
-# 
-if (stat -c "%a" /etc/bin/keyrings/docker.asc)
+
+if (test -f /etc/bin/keyrings/docker.gpg)
 then
   echo " gpg keyring already configured"
 else
   echo "configuring gpg keyrings"
-  sudo chmod a+r /etc/apt/keyrings/docker.asc
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
 fi
-

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -36,7 +36,8 @@ else
   echo "configuring gpg keyring"
   curl -fsSL https://download.docker.com/linux/debian/gpg | sudo -H gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 fi
-
+ 
+# setting permissions 
 if (test -f /etc/bin/keyrings/docker.gpg)
 then
   echo " gpg keyring already configured"

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -1,24 +1,21 @@
+# Update
+sudo apt update
+
+# Installing curl
 if (which curl)
 then 
   echo "curl already installed"
 else
   echo "Installing curl"
-  sudo apt update
   sudo apt install curl
 fi
 
-if (test -f /etc/apt/keyrings/docker.asc)
+# Adding, and configuration of gpg keyring
+if [ -f /etc/apt/keyrings/docker.asc ]
 then 
-  echo "Keyrings already present"
+  echo "gpg keyring alread configured"
 else 
-  echo "Creating keyrings"
-  sudo install -m 0755 -d /etc/apt/keyrings
+  echo "configuring gpg keyring"
+  sudo install -m 0755 -d /etc/apt/keyrings curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc chmod a+r /etc/apt/keyrings/docker.asc
 fi
 
-if (which gpg)
-then 
-  echo "Gpg alraed installed"
-else
-  echo "Installing, and configuring gpg"
-  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
-fi

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -1,0 +1,24 @@
+if (which curl)
+then 
+  echo "curl already installed"
+else
+  echo "Installing curl"
+  sudo apt update
+  sudo apt install curl
+fi
+
+if (test -f /etc/apt/keyrings/docker.asc)
+then 
+  echo "Keyrings already present"
+else 
+  echo "Creating keyrings"
+  sudo install -m 0755 -d /etc/apt/keyrings
+fi
+
+if (which gpg)
+then 
+  echo "Gpg alraed installed"
+else
+  echo "Installing, and configuring gpg"
+  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+fi

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -1,5 +1,5 @@
  Update
-sudo apt update
+sudo apt-get update
 
 # Installing ca-certificates
 if (which ca-certificates)
@@ -7,7 +7,7 @@ then
   echo "ca-certificates already installed"
 else
   echo "Installing ca-certificates"
-  sudo apt install ca-certificates
+  sudo apt-get install ca-certificates
 fi
 
 # Installing curl
@@ -16,15 +16,15 @@ then
   echo "curl already installed"
 else
   echo "Installing curl"
-  sudo apt install curl
+  sudo apt-get install curl
 fi
 
-if (test -f /etc/bin/keyring)
+if (test -f /etc/bin/keyrings)
 then
-  echo "creatingg keyring"
+  echo "creating keyrings"
 else
-  echo "Creating keyring"
-  sudo apt install /etc/apt/keyrings
+  echo "Creating keyrings"
+  sudo install -m 0755 -d /etc/apt/keyrings
 fi
 
 # Adding, and configuration of gpg keyring
@@ -33,10 +33,10 @@ then
   echo "gpg keyring exists, and configured"
 else
   echo "configuring gpg keyring"
-  sudo curl-fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc 
+  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc 
 fi
 
-if (test -f /etc/bin/keyring/docker.asc)
+if (test -f /etc/bin/keyrings/docker.asc)
 then
   echo "gpg keyring configured"
 else

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -19,7 +19,7 @@ else
   sudo apt install -y curl 
 fi
 
-# Creating a keyrings directory
+# Creating a keyrings directory 
 if (test -d /etc/bin/keyrings)
 then
   echo "creating keyrings"
@@ -28,7 +28,7 @@ else
   sudo install -m 0755 -d /etc/apt/keyrings
 fi
 
-# Adding gpg keyring, and configuring
+# Adding gpg keyring
 if (which gpg)
 then
   echo "gpg keyring exists, and configured"
@@ -36,8 +36,9 @@ else
   echo "configuring gpg keyring"
   sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
 fi
-
-if (test -f /etc/bin/keyrings/docker.asc)
+ 
+# 
+if (stat -c "%a" /etc/bin/keyrings/docker.asc)
 then
   echo " gpg keyring already configured"
 else

--- a/dockers-install.sh
+++ b/dockers-install.sh
@@ -34,7 +34,7 @@ then
   echo "gpg keyring exists, and configured"
 else
   echo "configuring gpg keyring"
-  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; sudo chmod a+r /etc/apt/keyrings/docker.asc
+  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
 fi
 
 if (test -f /etc/bin/keyrings/docker.asc)


### PR DESCRIPTION
…stall file.

- Was able to use `test -f plus/file/path` to search for a file, It seams to work fine?
- Removed all the apt-get commands, and all the commands worked so I incorporated that into my new install script.
- Have not tested on a clean dockerless OS.
- Also got rid of the ca-certificates, YOU were right that was two commands my `which ca-certificates curl` was searching for just curl.lol
# what is ca-certificates?
- Short - It is a digital certificate that is used to verify the identity of 3rd parties, and encrypt data between you and said 3rd party.

- Long - A certificate authority (ca), is a trusted entity (like Comodo) that issues digital documents that can be used like a digital passport. When we go to a website (like google.com), Google will send you their certificate. Our browsers do a little magic with the ca-certificate, and either verify or reject the certificate provided by Google.

